### PR TITLE
Super properties now functions instead of constant values

### DIFF
--- a/Assets/Mixpanel/Mixpanel.cs
+++ b/Assets/Mixpanel/Mixpanel.cs
@@ -17,7 +17,7 @@ public static class Mixpanel
 	public static bool EnableLogging;
 
 	// Add any custom "super properties" to this dictionary. These are properties sent with every event.
-	public static Dictionary<string, object> SuperProperties = new Dictionary<string, object>();
+	public static Dictionary<string, Func<object>> SuperProperties = new Dictionary<string, Func<object>>();
 
 	private const string API_URL_FORMAT = "https://api.mixpanel.com/track/?data={0}";
 	private static MonoBehaviour _coroutineObject;
@@ -52,15 +52,16 @@ public static class Mixpanel
 		propsDict.Add("token", Token);
 		foreach(var kvp in SuperProperties)
 		{
-			if(kvp.Value is float) // LitJSON doesn't support floats.
+			var value = kvp.Value();
+			if(value is float) // LitJSON doesn't support floats.
 			{
-				float f = (float)kvp.Value;
+				float f = (float)value;
 				double d = f;
 				propsDict.Add(kvp.Key, d);
 			}
 			else
 			{
-				propsDict.Add(kvp.Key, kvp.Value);
+				propsDict.Add(kvp.Key, value);
 			}
 		}
 		if(properties != null)

--- a/Assets/Mixpanel/MixpanelExample.cs
+++ b/Assets/Mixpanel/MixpanelExample.cs
@@ -17,10 +17,10 @@ public class MixpanelExample : MonoBehaviour
 		Mixpanel.DistinctID = DistinctID;
 
 		// Set some "super properties" to be sent with every event.
-		Mixpanel.SuperProperties.Add("platform", Application.platform.ToString());
-		Mixpanel.SuperProperties.Add("quality", QualitySettings.names[QualitySettings.GetQualityLevel()]);
-		Mixpanel.SuperProperties.Add("fullscreen", Screen.fullScreen);
-		Mixpanel.SuperProperties.Add("resolution", Screen.width + "x" + Screen.height);
+		Mixpanel.SuperProperties.Add("platform", () => Application.platform.ToString());
+		Mixpanel.SuperProperties.Add("quality", () => QualitySettings.names[QualitySettings.GetQualityLevel()]);
+		Mixpanel.SuperProperties.Add("fullscreen", () => Screen.fullScreen);
+		Mixpanel.SuperProperties.Add("resolution", () => Screen.width + "x" + Screen.height);
 	}
 
 	public void OnGUI()

--- a/README.mdown
+++ b/README.mdown
@@ -53,7 +53,7 @@ Super properties are an easy way to store data about your users. They are global
 
 If you want to register a super property for your current user, you can do it as follows:
 
-	Mixpanel.SuperProperties.Add("name of super_property", value_of_super_property); // Most common types such as int, float, double, and string are supported.
+	Mixpanel.SuperProperties.Add("name of super_property", () => value_of_super_property); // Most common types such as int, float, double, and string are supported.
 
 It's often useful to log data about your application with all events. For example, we can add some super properties to the `Start` method we created earlier:
 
@@ -62,10 +62,10 @@ It's often useful to log data about your application with all events. For exampl
 		Mixpanel.Token = "YOUR MIXPANEL TOKEN HERE";
 
 		// Set some "super properties" to be sent with every event.
-		Mixpanel.SuperProperties.Add("platform", Application.platform.ToString());
-		Mixpanel.SuperProperties.Add("quality", QualitySettings.names[QualitySettings.GetQualityLevel()]);
-		Mixpanel.SuperProperties.Add("fullscreen", Screen.fullScreen);
-		Mixpanel.SuperProperties.Add("resolution", Screen.width + "x" + Screen.height);
+		Mixpanel.SuperProperties.Add("platform", () => Application.platform.ToString());
+		Mixpanel.SuperProperties.Add("quality", () => QualitySettings.names[QualitySettings.GetQualityLevel()]);
+		Mixpanel.SuperProperties.Add("fullscreen", () => Screen.fullScreen);
+		Mixpanel.SuperProperties.Add("resolution", () => Screen.width + "x" + Screen.height);
 	}
 
 # Identifying a User #


### PR DESCRIPTION
Since they are sent on every event, it doesn't make sense to save them as constant values — better to save delegates that determine their values.
